### PR TITLE
修复合并数组出错

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -33,7 +33,12 @@ class ArrayObject extends \ArrayObject
         $merge = function ($array1, $array2) use (&$merge) {
             foreach ($array2 as $key => $value) {
                 if (array_key_exists($key, $array1) && is_array($value)) {
-                    $array1[$key] = $merge($array1[$key], $array2[$key]);
+                    if (is_array($array1[$key])) {
+                        $array1[$key] = $merge($array1[$key], $value);
+                    } else {
+                        array_unshift($value, $array1[$key]);
+                        $array1[$key] = $value;
+                    }
                 } else {
                     $array1[$key] = $value;
                 }

--- a/tests/ArrayObjectTest.php
+++ b/tests/ArrayObjectTest.php
@@ -89,6 +89,35 @@ class ArrayObjectTest extends PHPUnit_Framework_TestCase
                 ]
             ]
         ], $this->array->getArrayCopy());
+
+
+        $this->array->merge([
+            'foo' => null,
+        ]);
+
+        $this->array->merge([
+            'foo' => [
+                'bar' => 'var',
+            ],
+        ]);
+
+        $this->assertSame(
+            [
+                'foo' => [
+                    0 => NULL,
+                    'bar' => 'var',
+                ],
+                'foobar' => 'zyc',
+                'database' => [
+                    'host' => '127.0.0.1',
+                    'options' => [
+                        'foo' => 'bar',
+                        'foobar' => 'zyc',
+                    ],
+                ],
+            ],
+            $this->array->getArrayCopy()
+        );
     }
 
     public function testArrayKey()


### PR DESCRIPTION
```
$a = [
    'foo' => null,
];
$a = [
    'foo' => [
        'bar' => 'var',
    ],
];
```
通过 ArrayObject::merge() 合并时, 其中的匿名函数在第一次递归时, 会传入 `null` 跟 `['bar' => 'var']`, 
然后在遍历 `['bar' => 'var']` 是会调用 `array_key_exists($key, $array1)` 即 `array_key_exists('bar', null)`, 从而触发一个 Warning